### PR TITLE
[PTECH] add shopping_cart_id to /bookings endpoint docs

### DIFF
--- a/spec/components/schema/bookings.yaml
+++ b/spec/components/schema/bookings.yaml
@@ -21,7 +21,10 @@ components:
           properties:
             booking:
               type: object
+              description: The booking object, you may specify an already existing shopping cart the booking shall be added to. If no `shopping_cart_id` is specified a new cart is automatically created for the booking. 
               properties:
+                shopping_cart_id:
+                  $ref: "../commons/fields.yaml#/components/schemas/ShoppingCartId"
                 bookable:
                   type: object
                   properties:


### PR DESCRIPTION
### Description

Small update to the /bookings endpoint docs. Now mentions and explains the usage of the shopping_cart_id as part of the POST @ /bookings request.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
