### PR TITLE
Remove timezone from update timestamp

### DIFF
--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -215,7 +215,7 @@ components:
           description: The timestamp of the last update to the available entity (in UTC).
           type: string
           format: date-time
-          example: '2023-01-23T04:56:07+00:00'
+          example: '2023-01-23T04:56:07'
   responses:
     AvailabilityResponse:
       description: Successful response


### PR DESCRIPTION
### Description

Since we already mention in the description that the timestamp is in UTC, we do not need to add the timezone. We adjusted the example according to this idea.

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

