### PR TITLE
Deprecating price input parameter in bookings endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ For sensitive security matters please contact [security@getyourguide.com](mailto
 
 ## Legal
 
-Copyright 2021 GetYourGuide GmbH.
+Copyright 2023 GetYourGuide GmbH.
 
 **partner-api-spec** is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for the full text.

--- a/spec/components/commons/fields.yaml
+++ b/spec/components/commons/fields.yaml
@@ -217,6 +217,11 @@ components:
       description: The value of the price.
       example: 15.15
       type: number
+    DeprecatedPrice:
+      deprecated: true
+      description: Deprecated! These value is not required anymore for making a booking, we will calculate the best price we can offer based on the current availability.
+      example: 15.15
+      type: number
     Rating:
       description: The value of the rating.
       minimum: 0

--- a/spec/components/schema/bookings.yaml
+++ b/spec/components/schema/bookings.yaml
@@ -35,7 +35,7 @@ components:
                     datetime:
                       $ref: "../commons/fields.yaml#/components/schemas/Datetime"
                     price:
-                      $ref: "../commons/fields.yaml#/components/schemas/Price"
+                      $ref: "../commons/fields.yaml#/components/schemas/DeprecatedPrice"
                     categories:
                       type: array
                       items:
@@ -54,7 +54,6 @@ components:
                   required:
                     - option_id
                     - datetime
-                    - price
                     - categories
     RedeemCoupon:
       type: object


### PR DESCRIPTION
### Description

Given the fact that the pricing structure has changed in our system (e.g. now you need to consume the prices from /price-breakdown endpoint) we have deprecated the price parameter and removed the constraints we were doing to check for price mismatches.
This means that from now on, we will calculate the price that best fits the booking parameters (date, option, number of participants, etc) on our side, reducing the complexity from consumers.

<img width="1728" alt="Screenshot 2023-05-04 at 10 10 28" src="https://user-images.githubusercontent.com/13257788/236148448-ce56c44c-9a97-4e18-a53e-0066f21e43a2.png">
