### PR TITLE
[HOTFIX] Make addon id and quantity non-nullable

### DIFF
--- a/spec/components/schema/day_breakdowns.yaml
+++ b/spec/components/schema/day_breakdowns.yaml
@@ -358,8 +358,8 @@ components:
               items:
                 type: object
                 required:
-                  - addon_id
-                  - participants
+                  - id
+                  - quantity
                 properties:
                   id:
                     type: integer


### PR DESCRIPTION
### Description
Fixing the typo in the specs of daybreakdown endpoint about addons

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

#### Screenshot (Optional)

New features / fixes can include a gif or screenshot of the functionality.
