### PR TITLE
[PTECH-4488] Add non-documented fields in Metadata to the specs

### DIFF
--- a/spec/components/schema/metadata.yaml
+++ b/spec/components/schema/metadata.yaml
@@ -11,6 +11,12 @@ components:
         descriptor:
           type: string
           example: GetYourGuide AG
+        date:
+          $ref: "../commons/fields.yaml#/components/schemas/Datetime"
+        status:
+          type: string
+          description: Status of the request
+          example: "OK"
         query:
           type: string
           description: URL parameters used for the request sent


### PR DESCRIPTION
### Description

Status and date fields were part of the metadata object but they were not documented. I added them to the public specs as well 👍

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

#### Screenshot (Optional)

New features / fixes can include a gif or screenshot of the functionality.
