### PR TITLE
Updating specs deprecating booking and cart id

### DIFF
--- a/spec/components/commons/fields.yaml
+++ b/spec/components/commons/fields.yaml
@@ -10,7 +10,8 @@ components:
       example: WTLDAJ2S335O539FV3YCGZ0JMOCSTB5M
       type: string
     BookingId:
-      description: The id of the booking.
+      deprecated: true
+      description: The id of the booking. (Use booking hash)
       example: 13822240
       type: integer
     BookingStatus:
@@ -236,7 +237,8 @@ components:
       example: 0ESFMXPUANBNSGAOSLR4JWCOD7S4P18K
       type: string
     ShoppingCartId:
-      description: The ID of the shopping cart.
+      deprecated: true
+      description: The ID of the shopping cart. (Use shopping cart hash)
       example: 32724458
       type: number
     State:

--- a/spec/components/schema/carts.yaml
+++ b/spec/components/schema/carts.yaml
@@ -23,6 +23,8 @@ components:
               properties:
                 shopping_cart_id:
                   $ref: "../commons/fields.yaml#/components/schemas/ShoppingCartId"
+                shopping_cart_hash:
+                  $ref: "../commons/fields.yaml#/components/schemas/ShoppingCartHash"
                 billing:
                   $ref: "#/components/schemas/Billing"
                 traveler:


### PR DESCRIPTION
### Description

Updating specs deprecating booking and cart id, From now on hashes should be used in the booking flow.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

#### Screenshot (Optional)

New features / fixes can include a gif or screenshot of the functionality.
