### PR TITLE
PTECH-6285: update public PPAPI specs to include new Tour fields. 

### DIFF
--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -45,6 +45,24 @@ components:
           type: string
           description: Additional information for the customer.
           example: Tickets must be used by the same person on all days...you must present the actual Universal Orlando ticket to receive entry to the parks.
+        items_to_bring:
+          type: array
+          description: Recommended items the customer should bring.
+          items:
+            type: string
+          example: ["Comfortable shoes", "Sunscreen"]
+        not_allowed:
+          type: array
+          description: Things that are not allowed to bring to the activity.
+          items:
+            type: string
+          example: [ "Alcohol", "Pets" ]
+        not_suitable_for:
+          type: array
+          description: Certain demographics for whom this activity is not suitable.
+          items:
+            type: string
+          example: [ "Children under 3 years", "People with impeded movement." ]
         bestseller:
           type: boolean
           description: Flag if the tour is a bestseller.


### PR DESCRIPTION
### Description

Updating the public docs to include the three new fields for the tours object.

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
