### PR TITLE
adding pick up location support

### DIFF
--- a/spec/components/commons/objects.yaml
+++ b/spec/components/commons/objects.yaml
@@ -21,6 +21,9 @@ components:
           $ref: "fields.yaml#/components/schemas/State"
     Coordinates:
       type: object
+      required:
+        - lat
+        - long
       properties:
         lat:
           $ref: "fields.yaml#/components/schemas/Latitude"
@@ -178,5 +181,153 @@ components:
           $ref: "fields.yaml#/components/schemas/Datetime"
         closing_time:
           $ref: "fields.yaml#/components/schemas/Datetime"
+    PickUpLocation:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: |
+            Indicates the source type for pickup. Possible values:
+            - from_areas
+            - from_locations
+        description:
+          description: Description of the pick up location translated to the language of the user.
+          example: "Pick up from your hotel in Manhattan"
+          type: string
+        areas:
+          type: array
+          description: "Provide this if type is 'from_areas'."
+          items:
+            $ref: "../commons/objects.yaml#/components/schemas/LogisticsArea"
+        locations:
+          type: array
+          description: "Provide this if type is 'from_locations'."
+          items:
+            $ref: "../commons/objects.yaml#/components/schemas/LogisticsLocation"
+        transportation_types:
+          type: array
+          items:
+            $ref: "../commons/objects.yaml#/components/schemas/TransportationType"
+    TransportationType:
+      type: object
+      required: [mode]
+      properties:
+        mode:
+          type: string
+          description: |
+            Possible values:
+            - bicycle
+            - mountain_bike
+            - electric_bicycle
+            - motorcycle
+            - scooter
+            - segway
+            - car
+            - limousine
+            - jeep_suv
+            - van
+            - quad_atv
+            - bus_coach
+            - electric_car
+            - vintage_car
+            - black_cab
+            - sailboat
+            - ferry
+            - gondola
+            - duck_boat
+            - jet_ski
+            - sightseeing_cruise
+            - water_taxi
+            - river_boat
+            - kayak
+            - raft
+            - catamaran
+            - speed_boat
+            - yacht
+            - canoe
+            - stand_up_paddle_board
+            - surfboard
+            - submarine
+            - other_water_transport
+            - train
+            - tram
+            - helicopter
+            - airplane
+            - balloon
+            - glider
+            - cable_car
+            - pedicab_rickshaw
+            - horse_carriage
+            - camel
+            - snowmobile
+            - sled
+            - other_animal
+            - public
+            - glass_bottom_boat
+            - lake_cruise
+            - banana_boat
+            - beer_boat
+            - air_boat
+            - dhow
+            - subway
+            - beer_bike
+            - trike
+            - tuk_tuk
+            - golf_cart
+            - motorized_tuk_tuk
+            - on_foot
+            - horse
+            - trolley
+    LogisticsArea:
+      type: object
+      required:
+        - name
+        - full_address
+        - bounding_box
+        - coordinates
+      properties:
+        name:
+          type: string
+          description: Name of the area. Shorter than full_address e.g. "Manhattan".
+        full_address:
+          type: string
+          description: Representing the area for the pick up location e.g. "Manhattan, New York, USA".
+        bounding_box:
+          $ref: "../commons/objects.yaml#/components/schemas/BoundingBox"
+        coordinates:
+          $ref: "../commons/objects.yaml#/components/schemas/Coordinates"
+    LogisticsLocation:
+      type: object
+      required:
+        - name
+        - full_address
+        - bounding_box
+        - coordinates
+      properties:
+        name:
+          type: string
+          description: Name of the location. Shorter than full_address e.g. Louvre Museum.
+        full_address:
+          type: string
+          description: Representing the location for the pick up location e.g. Louvre Museum, Paris, France.
+        coordinates:
+          $ref: "../commons/objects.yaml#/components/schemas/Coordinates"
+    BoundingBox:
+      type: object
+      properties:
+        sw_lat:
+          type: number
+          format: double
+        sw_long:
+          type: number
+          format: double
+        ne_lat:
+          type: number
+          format: double
+        ne_long:
+          type: number
+          format: double
 
 

--- a/spec/components/schema/bookings.yaml
+++ b/spec/components/schema/bookings.yaml
@@ -162,7 +162,7 @@ components:
             type: object
             properties:
               category_id:
-                $ref: ../commons/fields.yaml#/components/schemas/CategoryId
+                $ref: "../commons/fields.yaml#/components/schemas/CategoryId"
               name:
                 type: string
                 example: Adults
@@ -384,6 +384,18 @@ components:
               type: string
               description: Booking accommodation / hotel value.
               example: Hilton Miami Downtown hotel
+        booking_pick_up_location:
+          type: object
+          required:
+            - full_address
+            - coordinates
+          properties:
+            full_address:
+              type: string
+              description: Address to be picked up.
+              example: 1601 Biscayne Blvd, Miami, FL 33132, United States
+            coordinates:
+              $ref: "../commons/objects.yaml#/components/schemas/Coordinates"
         booking_flight_details:
           type: object
           required:

--- a/spec/components/schema/option.yaml
+++ b/spec/components/schema/option.yaml
@@ -23,6 +23,8 @@ components:
         pick_up:
           type: string
           description: Information about the hotel pickup possibilities.
+        pick_up_location:
+          $ref: "../commons/objects.yaml#/components/schemas/PickUpLocation"
         meeting_point:
           type: string
           description: Information about where to meet.
@@ -89,6 +91,7 @@ components:
                       booking_child_safety_seat,
                       booking_cruise_details,
                       booking_customer_accommodation,
+                      booking_pick_up_location,
                       booking_drop_off_address,
                       booking_flight_details,
                       booking_medical_conditions,

--- a/spec/paths/carts.yaml
+++ b/spec/paths/carts.yaml
@@ -31,9 +31,7 @@ paths:
                     type: object
                     properties:
                       shopping_cart:
-                        oneOf:
-                          - $ref: "../components/schema/carts.yaml#/components/schemas/CartsConfirmResponseConfirmed"
-                          - $ref: "../components/schema/carts.yaml#/components/schemas/CartsConfirmResponseInPayment"
+                        $ref: "../components/schema/carts.yaml#/components/schemas/CartsConfirmResponseConfirmed"
         4XX:
           $ref: "../components/schema/errors.yaml#/components/responses/4XX"
         default:


### PR DESCRIPTION
This pull request introduces several schema updates and enhancements across multiple YAML files to improve the structure and functionality of the API specifications. Key changes include the addition of new schemas for logistics and transportation, updates to existing schemas to include new references, and a simplification of a response schema in the `carts.yaml` file.

### New Schema Additions:
* Added new schemas in `spec/components/commons/objects.yaml` for `PickUpLocation`, `TransportationType`, `LogisticsArea`, `LogisticsLocation`, and `BoundingBox`, providing detailed structures for logistics and transportation-related data.

### Updates to Existing Schemas:
* Updated the `Coordinates` schema in `spec/components/commons/objects.yaml` to include `lat` and `long` as required fields.
* Added a new property `booking_pick_up_location` to the `bookings.yaml` schema, referencing the `Coordinates` schema for pickup location details.
* Updated the `option.yaml` schema to include a reference to the new `PickUpLocation` schema and added `booking_pick_up_location` to the list of booking-related properties. [[1]](diffhunk://#diff-0fc875059ba2db29593a8709ea45a14d4f53f1aa0456885d034f236c8cd83ef4R26-R27) [[2]](diffhunk://#diff-0fc875059ba2db29593a8709ea45a14d4f53f1aa0456885d034f236c8cd83ef4R94)

### Miscellaneous Fixes:
* Corrected the reference format for `CategoryId` in `spec/components/schema/bookings.yaml` to use consistent quoting.

### Simplification of Response Schema:
* Simplified the `shopping_cart` property in `spec/paths/carts.yaml` by removing the `oneOf` structure and directly referencing `CartsConfirmResponseConfirmed`.