### PR TITLE
PTECH-NO-TICKET: more fixes to carts response schema

### DIFF
--- a/spec/components/schema/carts.yaml
+++ b/spec/components/schema/carts.yaml
@@ -32,10 +32,30 @@ components:
                 payment:
                   oneOf:
                     - $ref: "./payment.yaml#/components/schemas/MasterBill"
-                required:
-                - billing
-                - traveler
-                - payment
+              required:
+              - billing
+              - traveler
+              - payment
+
+    CartsResponseBase:
+      type: object
+      properties:
+        shopping_cart_id:
+          $ref: "../commons/fields.yaml#/components/schemas/ShoppingCartId"
+        shopping_cart_hash:
+          $ref: "../commons/fields.yaml#/components/schemas/ShoppingCartHash"
+        billing:
+          $ref: "#/components/schemas/BillingBase"
+        traveler:
+          $ref: "#/components/schemas/TravelerBase"
+        status:
+          $ref: "#/components/schemas/Status"
+        bookings:
+          $ref: "../schema/bookings.yaml#/components/schemas/Booking"
+        payment_process:
+          $ref: "./payment.yaml#/components/schemas/PaymentProcess"
+        payment_info:
+          $ref: "./payment.yaml#/components/schemas/PaymentInfoInPayment"
 
     CartsConfirmResponseConfirmed:
       type: object
@@ -77,6 +97,17 @@ components:
 
     # Cart Objects
     Billing:
+      allOf:
+      - $ref: "#/components/schemas/BillingBase"
+      - type: object
+        required:
+        - first_name
+        - last_name
+        - email
+        - country_code
+        - phone_number
+
+    BillingBase:
       type: object
       properties:
         salutation_code:
@@ -107,14 +138,18 @@ components:
           $ref: "../commons/fields.yaml#/components/schemas/Country"
         phone_number:
           $ref: "../commons/fields.yaml#/components/schemas/PhoneNumber"
-      required:
+
+    Traveler:
+      allOf:
+      - $ref: "#/components/schemas/TravelerBase"
+      - type: object
+        required:
         - first_name
         - last_name
         - email
-        - country_code
         - phone_number
 
-    Traveler:
+    TravelerBase:
       type: object
       properties:
         salutation_code:
@@ -127,11 +162,6 @@ components:
           $ref: "../commons/fields.yaml#/components/schemas/Email"
         phone_number:
           $ref: "../commons/fields.yaml#/components/schemas/PhoneNumber"
-      required:
-        - first_name
-        - last_name
-        - email
-        - phone_number
 
     # Data fields in carts object:
     Status:

--- a/spec/paths/carts.yaml
+++ b/spec/paths/carts.yaml
@@ -62,7 +62,7 @@ paths:
                     type: object
                     properties:
                       shopping_cart:
-                        $ref: "../components/schema/carts.yaml#/components/schemas/CartsConfirmResponseConfirmed"
+                        $ref: "../components/schema/carts.yaml#/components/schemas/CartsResponseBase"
         4XX:
           $ref: "../components/schema/errors.yaml#/components/responses/4XX"
         default:


### PR DESCRIPTION
### Description

- changing the response type for GET@carts where fields in Traveler and Billing Object are all optional.
- this for the case when cart is in state 'open' (right after POST@bookings), and no traveler and billing info have not been provided yet.
- fixing indentation mistake

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

#### Screenshot (Optional)

New features / fixes can include a gif or screenshot of the functionality.
