### PR TITLE
fix bookings to be array instead of object

### DIFF
--- a/spec/components/schema/carts.yaml
+++ b/spec/components/schema/carts.yaml
@@ -51,7 +51,9 @@ components:
         status:
           $ref: "#/components/schemas/Status"
         bookings:
-          $ref: "../schema/bookings.yaml#/components/schemas/Booking"
+          type: array
+          items:
+            $ref: "../schema/bookings.yaml#/components/schemas/Booking"
         payment_process:
           $ref: "./payment.yaml#/components/schemas/PaymentProcess"
         payment_info:
@@ -71,7 +73,9 @@ components:
         status:
           $ref: "#/components/schemas/Status"
         bookings:
-          $ref: "../schema/bookings.yaml#/components/schemas/Booking"
+          type: array
+          items:
+            $ref: "../schema/bookings.yaml#/components/schemas/Booking"
         payment_info:
           $ref: "./payment.yaml#/components/schemas/PaymentInfoConfirmed"
 
@@ -89,7 +93,9 @@ components:
         status:
           $ref: "#/components/schemas/Status"
         bookings:
-          $ref: "../schema/bookings.yaml#/components/schemas/Booking"
+          type: array
+          items:
+            $ref: "../schema/bookings.yaml#/components/schemas/Booking"
         payment_process:
           $ref: "./payment.yaml#/components/schemas/PaymentProcess"
         payment_info:


### PR DESCRIPTION
### Description

Fixing the response object spec from carts endpoint to display the bookings field as array.
- internal specs are already up-to-date

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

#### Screenshot (Optional)

New features / fixes can include a gif or screenshot of the functionality.
