### PR TITLE
NO-TICKET: mark tour_code field as deprecated.

### DIFF
--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -12,6 +12,7 @@ components:
         tour_id:
           $ref: "../commons/fields.yaml#/components/schemas/TourId"
         tour_code:
+          deprecated: true
           type: string
           description: Tour reference code.
           example: 2-Day

--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -14,7 +14,7 @@ components:
         tour_code:
           deprecated: true
           type: string
-          description: Tour reference code.
+          description: Deprecated
           example: deprecated
         cond_language:
           type: array

--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -15,7 +15,7 @@ components:
           deprecated: true
           type: string
           description: Tour reference code.
-          example: 2-Day
+          example: deprecated
         cond_language:
           type: array
           description: Available conduction languages.

--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -14,7 +14,7 @@ components:
         tour_code:
           deprecated: true
           type: string
-          description: Deprecated
+          description: Deprecated field, does not contain any meaningful information.
           example: deprecated
         cond_language:
           type: array


### PR DESCRIPTION
### Description

Properly marking field `tour_code` field as deprecated. 

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

#### Screenshot (Optional)

New features / fixes can include a gif or screenshot of the functionality.
