### PR TITLE
Add self_guided to guide_type enum

### DIFF
--- a/spec/components/schema/tour.yaml
+++ b/spec/components/schema/tour.yaml
@@ -140,6 +140,7 @@ components:
             - instructor
             - driver
             - live_tour_guide
+            - self_guided
           description: >
             Type of guide that is conducting the tour, available are
               * `none`: no guide available for this tour.
@@ -147,6 +148,7 @@ components:
               * `instructor`: an instructor e.g. for diving classes.
               * `driver`: a driver for motorized tours.
               * `live_tour_guide`: a standard live tour guide.
+              * `self_guided`: tour conducted without a guide; the customer explores on their own.
         mobile_voucher:
           type: boolean
           description: If the tour accepts mobile voucher.


### PR DESCRIPTION
### Description

Adds `self_guided` to the `guide_type` enum in `spec/components/schema/tour.yaml`, mirroring the change made to the internal OpenAPI spec in [public-partner-api#1788](https://github.com/getyourguide/public-partner-api/pull/1788).

`self_guided` means: tour conducted without a guide; the customer explores on their own. `search-api-low-prio` already returns this value in responses, so the public spec needed to be updated to reflect it.

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)