### PR TITLE
SPTECH-402: Override reviews limit parameter maximum to 50

### DIFF
--- a/spec/paths/reviews.yaml
+++ b/spec/paths/reviews.yaml
@@ -17,7 +17,7 @@ paths:
         - $ref: "#/components/parameters/date"
         - $ref: "#/components/parameters/sortfield"
         - $ref: "../components/commons/query.yaml#/components/parameters/sortdirection"
-        - $ref: "../components/commons/query.yaml#/components/parameters/limit"
+        - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/offset"
       responses:
         200:
@@ -45,6 +45,13 @@ paths:
           $ref: "../components/schema/errors.yaml#/components/responses/Default"
 components:
   parameters:
+    limit:
+      description: Number of reviews to retrieve. Maximum value for this endpoint is 50.
+      in: query
+      name: limit
+      required: false
+      schema:
+        $ref: "#/components/schemas/Limit"
     sortfield:
       description: Defines the sort field.
       in: query
@@ -72,6 +79,13 @@ components:
   schemas:
     Datetime:
       $ref: "../components/commons/fields.yaml#/components/schemas/Datetime"
+    Limit:
+      description: Number of reviews to retrieve.
+      type: integer
+      minimum: 1
+      maximum: 50
+      default: 10
+      example: 10
     Offset:
       description: Offset the list of returned results by this amount.
       type: integer


### PR DESCRIPTION
## Summary

- The reviews endpoint enforces a max limit of 50 at the `user-generated-content` service level, but `spec/paths/reviews.yaml` was inheriting the global `Limit` schema (`maximum: 500`) via `$ref: "../components/commons/query.yaml#/components/parameters/limit"`.
- This spec gap led partner `31CDYPW` to send `limit=500` which is valid per spec but rejected upstream, causing a 400 from UGC that surface as a 500 in `public-partner-api`.
- Added a local `limit` parameter and `Limit` schema in `reviews.yaml` (following the existing pattern for `offset`) that overrides `maximum` to `50`. The global schema in `fields.yaml` and all other endpoints are untouched.

## Test plan

- [ ] Confirm `spec/paths/reviews.yaml` renders correctly in the API docs with `limit` max shown as 50
- [ ] Confirm no other path files reference the reviews-local limit schema
- [ ] Verify the OpenAPI spec bundle validates cleanly

Related Slack thread: https://getyourguide.slack.com/archives/C0AMUFRLBTR/p1783946666662039