### PR TITLE
SPTECH-269: expose min/max participants on price-breakdown timeslots

### DIFF
--- a/spec/components/schema/day_breakdowns.yaml
+++ b/spec/components/schema/day_breakdowns.yaml
@@ -54,6 +54,14 @@ components:
         vacancies:
           type: integer
           example: 10
+        min_participants:
+          type: integer
+          description: Minimum number of participants required to book this timeslot.
+          example: 2
+        max_participants:
+          type: integer
+          description: Maximum number of participants that can be booked on this timeslot.
+          example: 50
         unavailability_reason:
           $ref: '#/components/schemas/UnavailabilityReason'
         price_breakdown:


### PR DESCRIPTION
## What
Add `min_participants` / `max_participants` to the public `TimeSlot` schema (`spec/components/schema/day_breakdowns.yaml`).

## Why
The Partner API's `price-breakdown` now returns these two fields per time slot (shipped in public-partner-api). This repo is the public API reference; its spec is a manually-maintained mirror with no auto-sync, so it was missing them.

## How
Add the two fields to the `TimeSlot` schema, mirroring the internal change.

## Notes
- Scoped to just these fields — this mirror is otherwise stale vs the internal spec, but a full re-sync is out of scope here.
- Feeds the rendered reference at https://code.getyourguide.com/partner-api-spec/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)